### PR TITLE
 remove slot_epoch mock from svm-executor

### DIFF
--- a/svm/executor/src/mock/fork_graph.rs
+++ b/svm/executor/src/mock/fork_graph.rs
@@ -15,7 +15,5 @@ impl ForkGraph for MockForkGraph {
         }
     }
 
-    fn slot_epoch(&self, _slot: Slot) -> Option<Epoch> {
-        Some(0)
-    }
+    
 }


### PR DESCRIPTION
Resolves #29.
- Removed slot_epoch usage from svm-executor as per [anza-xyz/agave@106d4cf](https://github.com/anza-xyz/agave/commit/106d4cf399523079f9b214a635142ade99358047).


